### PR TITLE
Fix example for combining programs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ To prepend one or more DSL to an existing combination of DSL into a new program,
     for {
       _     <- Log.debug(s"Searching for value id: $id").freek[PRG]
       name  <- KVS.Get(id).freek[PRG]
-      e     <- DB.findById(id).freek[PRG]
+      e     <- DBService.findById(id).expand[PRG]
       file  <- File.Get(e.file).freek[PRG]
       _     <- Log.debug(s"Found file:$file").freek[PRG]
     } yield (file)


### PR DESCRIPTION
I couldn't get my usage of this feature to compile without using `expand[PRG]` in the subprogram as shown [in this test](https://github.com/ProjectSeptemberInc/freek/blob/master/src/test/scala/FreekitSpec.scala#L158).